### PR TITLE
Handle failed GitHub Actions notifications

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import type { Octokit } from "@octokit/rest";
 export async function markAllRenovateMergedNotificationsAsDone(
   octokit: Octokit,
 ) {
+  const isFailedConclusion = (conclusion?: string | null): boolean => conclusion === "failure";
   let page = 1;
   let hasMorePages = true;
 
@@ -25,6 +26,21 @@ export async function markAllRenovateMergedNotificationsAsDone(
     for (const notification of notifications) {
       const { subject, repository } = notification;
       const threadId = Number(notification.id);
+
+      if (subject.type === "CheckSuite") {
+        const checkSuite = await octokit.request(`GET ${subject.url}`);
+
+        if (isFailedConclusion(checkSuite.data.conclusion)) {
+          await octokit.rest.activity.markThreadAsDone({
+            thread_id: threadId,
+          });
+
+          // eslint-disable-next-line no-console
+          console.log(`done failed check suite: ${repository.full_name} : ${subject.title}`);
+        }
+
+        continue;
+      }
 
       if (subject.type !== "PullRequest")
         continue;
@@ -52,11 +68,11 @@ export async function markAllRenovateMergedNotificationsAsDone(
 
         // eslint-disable-next-line no-console
         console.log(`done ${limit} ${repository.full_name} : ${prData.title}`);
+        continue;
       }
-      else {
-        // eslint-disable-next-line no-console
-        console.log(`${limit} ${prData.user.login} : ${prData.merged}`);
-      }
+
+      // eslint-disable-next-line no-console
+      console.log(`${limit} ${prData.user.login} : ${prData.merged}`);
     }
 
     page += 1;


### PR DESCRIPTION
### Motivation
- Reduce notification noise by automatically marking failed GitHub Actions (CheckSuite) notifications as done. 
- Keep existing behavior that marks merged Renovate PR notifications as done while avoiding extra processing for those threads. 

### Description
- Add a small helper `isFailedConclusion` and branch on `subject.type === "CheckSuite"` in `src/api.ts` to fetch the check suite and mark the thread done when `conclusion === "failure"`. 
- Mark `CheckSuite` threads as done and `continue` to skip further processing for those notifications. 
- Ensure the existing Renovate merged PR handling remains and add an early `continue` after marking those threads as done, and tidy logging.

### Testing
- Ran `pnpm -s typecheck` and it succeeded. 
- Ran `pnpm -s lint` and it succeeded. 
- Ran `pnpm -s test --run` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1133d5ac832896e770f40f47730a)