### PR TITLE
Handle missing GitHub notification subject URLs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -26,9 +26,15 @@ export async function markAllRenovateMergedNotificationsAsDone(
     for (const notification of notifications) {
       const { subject, repository } = notification;
       const threadId = Number(notification.id);
+      const subjectUrl = subject.url;
+
+      if (!subjectUrl) {
+        console.warn(`skip notification with missing subject.url: ${notification.id} (${subject.type})`);
+        continue;
+      }
 
       if (subject.type === "CheckSuite") {
-        const checkSuite = await octokit.request(`GET ${subject.url}`);
+        const checkSuite = await octokit.request(`GET ${subjectUrl}`);
 
         if (isFailedConclusion(checkSuite.data.conclusion)) {
           await octokit.rest.activity.markThreadAsDone({
@@ -45,7 +51,11 @@ export async function markAllRenovateMergedNotificationsAsDone(
       if (subject.type !== "PullRequest")
         continue;
 
-      const prNumber = Number(subject.url.split("/").pop());
+      const prNumber = Number(subjectUrl.split("/").pop());
+      if (Number.isNaN(prNumber)) {
+        console.error(`error pull_number: ${subjectUrl}`);
+        continue;
+      }
       if (!repository.owner.login) {
         console.error(`error owner: ${repository.owner.login}`);
         continue;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by malformed request URLs like `https://api.github.comnull` when notification `subject.url` is missing.
- Make notification processing more robust against incomplete GitHub notification payloads.
- Avoid unnecessary failed network calls and noisy error traces such as `getaddrinfo ENOTFOUND api.github.comnull`.

### Description
- Introduced a `subjectUrl` variable and skip notifications when `subject.url` is falsy with a warning instead of issuing a request to `null`.
- Reused `subjectUrl` for `octokit.request` when handling `CheckSuite` notifications to ensure valid request targets.
- Parse the pull request number from `subjectUrl` and validate it with `Number.isNaN`, logging and skipping entries with invalid PR URLs.

### Testing
- Ran type checking with `pnpm -s typecheck`, which completed successfully.
- Ran linting with `pnpm -s lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b18b5ec988328ad5054fd302eafc3)